### PR TITLE
Added missing 'each'

### DIFF
--- a/PowerSystems/AC1ph_DC/Loads.mo
+++ b/PowerSystems/AC1ph_DC/Loads.mo
@@ -273,10 +273,10 @@ Consumes the desired power independent of voltage.</p>
         "= true to use input signal pq_in, otherwise use parameter pq0"
         annotation(Evaluate=true, choices(checkBox=true));
 
-      parameter SIpu.Power[2] pq0(min=0)={1,1}/sqrt(2)
+      parameter SIpu.Power[2] pq0(each min=0)={1,1}/sqrt(2)
         "fixed {active, reactive} power (start value if use_pq_in)"
         annotation(Dialog(enable=not use_pq_in));
-      Modelica.Blocks.Interfaces.RealInput[2] pq_in(min=0) if use_pq_in
+      Modelica.Blocks.Interfaces.RealInput[2] pq_in(each min=0) if use_pq_in
         "desired {active, reactive} power" annotation (Placement(transformation(
             origin={0,100},
             extent={{-10,-10},{10,10}},

--- a/PowerSystems/AC3ph/Sources.mo
+++ b/PowerSystems/AC3ph/Sources.mo
@@ -332,7 +332,7 @@ with variable power and voltage when 'pv' connected to a signal-input.</p>
   model PQsource "Power source, 3-phase dq0"
     extends Partials.PowerBase;
 
-    Modelica.Blocks.Interfaces.RealInput[2] pq_in(final unit="1") if  use_pq_in
+    Modelica.Blocks.Interfaces.RealInput[2] pq_in(each final unit="1") if  use_pq_in
       "{active, reactive} power" annotation (Placement(transformation(
           origin={60,100},
           extent={{-10,-10},{10,10}},


### PR DESCRIPTION
There were some missing 'each' keywords that prevent OpenModelica's new front-end to compile the models, see e.g. [PowerSystems.Examples.AC1ph_DC.Elementary.LoadAC](https://libraries.openmodelica.org/branches/newInst/PowerSystems/files/PowerSystems_PowerSystems.Examples.AC1ph_DC.Elementary.LoadAC.err) This PR fixes the issue.